### PR TITLE
Fix variables to use @ in allowed-command.erb template

### DIFF
--- a/templates/allowed-command.erb
+++ b/templates/allowed-command.erb
@@ -1,7 +1,7 @@
 <% if @comment -%>
-# <%= comment %>
+# <%= @comment %>
 <% end -%>
 <% allowed_env_variables.each do |env_variable| -%>
-Defaults!<%= command %> env_keep+=<%= env_variable %>
+Defaults!<%= @command %> env_keep+=<%= @env_variable %>
 <% end -%>
-<%= user_spec %> <%= host %>=(<%= run_as %>)<%= nopasswd %> <%= command %>
+<%= @user_spec %> <%= @host %>=(<%= @run_as %>)<%= @nopasswd %> <%= @command %>


### PR DESCRIPTION
Update templates/allowed-command.erb to support Puppet3 without warnings about deprecated variable usage.
