### PR TITLE
Option to require or not the User/Groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,4 +53,5 @@ The `allowed_command` type takes the following options (with defaults in bracket
 [*require_password*]      - require user to give password, setting to false sets 'NOPASSWD:' (true)
 [*comment*]               - comment to add to the file
 [*allowed_env_variables*] - allowed list of env variables ([])
+[*require_exist*]         - Require the Group or User to exist. Setting this to false for example is needed if the user groups come from Active Directory. (true)
 ```

--- a/manifests/allowed_command.pp
+++ b/manifests/allowed_command.pp
@@ -12,6 +12,7 @@
 #   [*require_password*]      - require user to give password, setting to false sets 'NOPASSWD:' (true)
 #   [*comment*]               - comment to add to the file
 #   [*allowed_env_variables*] - allowed list of env variables ([])
+#   [*require_exist*]         - Require the Group or User to exist.
 #
 # Example usage:
 #
@@ -40,7 +41,8 @@ define sudoers::allowed_command(
   $group            = undef,
   $require_password = true,
   $comment          = undef,
-  $allowed_env_variables = []
+  $allowed_env_variables = [],
+  $require_exist    = true,
 ) {
 
   if ($user == undef and $group == undef) {
@@ -57,11 +59,16 @@ define sudoers::allowed_command(
     default => "%${group}"
   }
 
-  $require_spec = $group ? {
-    undef   => $user ? { 'ALL' => undef, default => User[$user] },
-    default => Group[$group]
+  if $require_exist {
+    $require_spec = $group ? {
+      undef   => $user ? { 'ALL' => undef, default => User[$user] },
+      default => Group[$group]
+    }
   }
 
+  if $no_require {
+    $require_spec = undef
+  }
 
   file { "/etc/sudoers.d/${filename}":
     ensure  => file,

--- a/manifests/allowed_command.pp
+++ b/manifests/allowed_command.pp
@@ -66,10 +66,6 @@ define sudoers::allowed_command(
     }
   }
 
-  if $no_require {
-    $require_spec = undef
-  }
-
   file { "/etc/sudoers.d/${filename}":
     ensure  => file,
     content => validate(template('sudoers/allowed-command.erb'), '/usr/sbin/visudo -cq -f'),


### PR DESCRIPTION
I'm working with PBIS and use Active Directory groups for the sudoer files so the group does not exist in Puppet. This option makes it that if set to false (default is true), it won't set a `require` parameter.

Are you planning to push this to the Puppet forge? Your built module there is pretty old.