### PR TITLE
Fix allowed_env_variables template bug.

### DIFF
--- a/templates/allowed-command.erb
+++ b/templates/allowed-command.erb
@@ -2,7 +2,7 @@
 # <%= @comment %>
 <% end -%>
 <% @allowed_env_variables.each do |env_variable| -%>
-Defaults!<%= @command %> env_keep+=<%= @env_variable %>
+Defaults!<%= @command %> env_keep+=<%= env_variable %>
 <% end -%>
 <% if @no_tty -%>
 Defaults!<%= @command %> !requiretty


### PR DESCRIPTION
erb should not contain an `@` before a variable in a for loop (see
https://docs.puppet.com/puppet/latest/lang_template_erb.html#iteration) however
@drt24 inserted one as part of 3f0ee33. As a result, if one tries to use the
`allowed_env_variables` parameter, `visudo` fails to validate the contents since
the created file has a line that ends `env_keep+=`.

This patch removes the erroneous `@`.