### PR TITLE
Add dependencies section to metadata.json.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "summary": "A simple template to semantically manage allowed commands in sudoers.d",
   "source": "https://github.com/phinze/puppet-sudoers",
+  "dependencies": [],  
   "project_page": "https://forge.puppetlabs.com/phinze/sudoers",
   "issues_url": "https://github.com/phinze/puppet-sudoers/issues",
   "tags": ["sudo", "sudoers"]


### PR DESCRIPTION
This is a required field [0]. Without this being specified puppet does not load
the module and so complains that `allowed_command` is an invalid resource type.

[0] https://docs.puppet.com/puppet/latest/modules_metadata.html#allowed-keys-in-metadatajson