### PR TITLE
Correct metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,5 +8,7 @@
   "dependencies": [],  
   "project_page": "https://forge.puppetlabs.com/phinze/sudoers",
   "issues_url": "https://github.com/phinze/puppet-sudoers/issues",
-  "tags": ["sudo", "sudoers"]
+  "tags": ["sudo", "sudoers"],
+  "dependencies": [
+  ]
 }


### PR DESCRIPTION
The `dependencies` param is required. Without it the module is broken, and `puppet module` commands will fail.